### PR TITLE
Replace the custom DateTime struct with a transparent wrapper around chrono's

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 num-bigint = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 bit-vec = "0.6"
-lazy_static = "0.2.1"
+lazy_static = "1"
 rustc-serialize = "0.3"
+chrono = "0.4"
 
 [dev-dependencies]
 rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate num_integer;
 pub extern crate bit_vec;
 #[macro_use]
 extern crate lazy_static;
+extern crate chrono;
 
 #[macro_use]
 pub mod derives;

--- a/tests/fakes.rs
+++ b/tests/fakes.rs
@@ -115,22 +115,8 @@ pub fn cert(get_random_printable_string: fn(usize) -> Vec<u8>)
                 issuer:
                     vec![(oid::dnQualifier.clone(),
                           TaggedDerValue::from_tag_and_bytes(TAG_PRINTABLESTRING, get_random_printable_string(42)))].into(),
-                validity_notbefore: DateTime {
-                    year: 1970,
-                    month: 1,
-                    day: 1,
-                    hour: 0,
-                    minute: 0,
-                    second: 0,
-                },
-                validity_notafter: DateTime {
-                    year: 1970,
-                    month: 1,
-                    day: 1,
-                    hour: 0,
-                    minute: 0,
-                    second: 0,
-                },
+                validity_notbefore: DateTime::new(1970, 1, 1, 0, 0, 0),
+                validity_notafter: DateTime::new(1970, 1, 1, 0, 0, 0),
                 subject:
                     vec![(oid::description.clone(),
                           TaggedDerValue::from_tag_and_bytes(TAG_UTF8STRING, b"Known keys only".to_vec())),


### PR DESCRIPTION
Addresses [Issue #1](https://github.com/fortanix/pkix/issues/1)
Also updates `lazy_static` from `0.2` to `1` because of deprecation warnings on such an old version