### PR TITLE
Add ECDSA Sig type

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -91,7 +91,7 @@ pub struct mgf1 {}
 impl DerWrite for mgf1 {
     fn write(&self, writer: DERWriter) {
         let algo = sha1 {};
-        &algo.write(writer);
+        let _ = &algo.write(writer);
     }
 }
 
@@ -159,7 +159,6 @@ derive_set_of! {
 }
 
 //RSAES_OAEP
-#[allow(non_camel_case_types)]
 define_algorithm! {
     KeyEncryptionAlgorithm => KeyEncryptionAlgorithmType {
         RSAES_OAEP = oid::RSAES_OAEP,
@@ -174,7 +173,6 @@ derive_sequence! {
     }
 }
 
-#[allow(non_camel_case_types)]
 define_algorithm! {
     SignatureAlgorithm  => SignatureAlgorithmType {
         RSASSA_PSS = oid::RSASSA_PSS,

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -14,6 +14,7 @@ lazy_static! {
     // PKCS #1
     pub static ref rsaEncryption: ObjectIdentifier = vec![1, 2, 840, 113549, 1, 1, 1].into();
     pub static ref sha256WithRSAEncryption: ObjectIdentifier = vec![1, 2, 840, 113549, 1, 1, 11].into();
+    pub static ref sha256WithECDSAEncryption: ObjectIdentifier = vec![1, 2, 840, 10045, 4, 3, 2].into();
 
     // X.500 attribute types
     pub static ref commonName: ObjectIdentifier = vec![2, 5, 4, 3].into();


### PR DESCRIPTION
Signature can be ECDSA instead of RSA. AWS Nitro wants ECDSA Certificates, this change allows a rust DSM client to generate CSRs and get them signed.