### PR TITLE
Add various new OIDs, types and methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkix"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Fortanix Inc."]
 license = "MPL-2.0"
 description = "TLS Certificate encoding and decoding helpers."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![recursion_limit="128"]
+#![recursion_limit="256"]
 
 pub extern crate yasna;
 pub extern crate num_bigint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,15 @@ pub use serialize::{DerWrite, ToDer};
 pub use deserialize::{FromDer, FromBer};
 
 pub use yasna::{ASN1Error, ASN1Result};
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+    use yasna::BERDecodable;
+    use std::fmt::Debug;
+
+    pub fn test_encode_decode<T: DerWrite + BERDecodable + Debug + PartialEq>(value: &T, expected_der: &[u8]) {
+        assert_eq!(yasna::construct_der(|w| value.write(w)), expected_der);
+        assert_eq!(&yasna::parse_der(expected_der, |r| T::decode_ber(r)).unwrap(), value);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![deny(warnings)]
 #![recursion_limit="128"]
 
 pub extern crate yasna;

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -22,6 +22,7 @@ lazy_static! {
 
     // X.509 certificate extensions
     pub static ref subjectAltName: ObjectIdentifier = vec![2, 5, 29, 17].into();
+    pub static ref issuerAltName: ObjectIdentifier = vec![2, 5, 29, 18].into();
     pub static ref basicConstraints: ObjectIdentifier = vec![2, 5, 29, 19].into();
     pub static ref subjectKeyIdentifier: ObjectIdentifier = vec![2, 5, 29, 14].into();
     pub static ref authorityKeyIdentifier: ObjectIdentifier = vec![2, 5, 29, 35].into();

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -43,6 +43,11 @@ lazy_static! {
     pub static ref NistP521: ObjectIdentifier = vec![1, 3, 132, 0, 35].into();
     pub static ref ecdsaWithSHA256: ObjectIdentifier = vec![1, 2, 840, 10045, 4, 3, 2].into();
 
+    // Brainpool curves: RFC5639, 4.1
+    pub static ref Brainpool256R1: ObjectIdentifier = vec![1, 3, 36, 3, 3, 2, 8, 1, 1, 7].into();
+    pub static ref Brainpool384R1: ObjectIdentifier = vec![1, 3, 36, 3, 3, 2, 8, 1, 1, 1].into();
+    pub static ref Brainpool512R1: ObjectIdentifier = vec![1, 3, 36, 3, 3, 2, 8, 1, 1, 13].into();
+
     // GOST elliptic curves: RFC4357
     pub static ref Gost256A: ObjectIdentifier = vec![1, 2, 643, 2, 2, 35, 1].into();
     pub static ref Gost256B: ObjectIdentifier = vec![1, 2, 643, 2, 2, 35, 2].into();

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -53,6 +53,12 @@ lazy_static! {
     pub static ref Gost256B: ObjectIdentifier = vec![1, 2, 643, 2, 2, 35, 2].into();
     pub static ref Gost256C: ObjectIdentifier = vec![1, 2, 643, 2, 2, 35, 3].into();
 
+    // X25519 identifiers: RFC 8410
+    pub static ref Curve25519: ObjectIdentifier = vec![1, 3, 101, 110].into();
+    pub static ref Curve448: ObjectIdentifier = vec![1, 3, 101, 111].into();
+    pub static ref Ed25519: ObjectIdentifier = vec![1, 3, 101, 112].into();
+    pub static ref Ed448: ObjectIdentifier = vec![1, 3, 101, 113].into();
+
     // CMS: RFC5652
     // named as id-ct-contentInfo in the standard.
     pub static ref ctContentInfo : ObjectIdentifier = vec![1, 2, 840, 113549, 1, 9, 16, 1, 6].into();

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -78,6 +78,14 @@ lazy_static! {
     pub static ref aes128_cbc : ObjectIdentifier    = vec![2, 16, 840, 1, 101, 3, 4, 1, 2].into();
     pub static ref RSASSA_PSS : ObjectIdentifier    = vec![1, 2, 840, 113549, 1, 1, 10].into();
     pub static ref messageDigest: ObjectIdentifier  = vec![1, 2, 840, 113549, 1, 9, 4].into();
+
+    // Korean cryptography - 전자서명인증체계 OID 가이드라인 (Object Identifier
+    // Guideline for the Electronic Signature Certification System V1.7)
+    pub static ref Kcdsa:       ObjectIdentifier = vec![1, 0, 14888, 3, 0, 2].into();
+    pub static ref KcdsaSha1:   ObjectIdentifier = vec![1, 2, 410, 200004, 1, 23].into();
+    pub static ref KcdsaSha224: ObjectIdentifier = vec![1, 2, 410, 200004, 1, 40].into();
+    pub static ref KcdsaSha256: ObjectIdentifier = vec![1, 2, 410, 200004, 1, 27].into();
+    pub static ref EcKcdsa:     ObjectIdentifier = vec![1, 0, 14888, 3, 0, 5].into();
 }
 
 lazy_static! {

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -197,10 +197,12 @@ lazy_static! {
             [1, 3, 6, 1, 5, 5, 7, 3, 8] => keyUsageTimeStamping,
             [1, 3, 6, 1, 5, 5, 7, 3, 9] => keyUsageOCSPSigning,
 
+            [1, 2, 840, 113549, 1, 1, 5] => sha1withRSA,
             [1, 2, 840, 113549, 1, 1, 14] => sha224withRSA,
             [1, 2, 840, 113549, 1, 1, 11] => sha256withRSA,
             [1, 2, 840, 113549, 1, 1, 12] => sha384withRSA,
             [1, 2, 840, 113549, 1, 1, 13] => sha512withRSA,
+            [1, 2, 840, 10045, 4, 1] => sha1withECDSA,
             [1, 2, 840, 10045, 4, 3, 1] => sha224withECDSA,
             [1, 2, 840, 10045, 4, 3, 2] => sha256withECDSA,
             [1, 2, 840, 10045, 4, 3, 3] => sha384withECDSA,

--- a/src/pem.rs
+++ b/src/pem.rs
@@ -28,6 +28,7 @@ pub const PEM_ENCRYPTED_PRIVATE_KEY: &'static PemGuard = pem_guard!("ENCRYPTED P
 pub const PEM_PRIVATE_KEY: &'static PemGuard = pem_guard!("PRIVATE KEY");
 pub const PEM_PUBLIC_KEY: &'static PemGuard = pem_guard!("PUBLIC KEY");
 pub const PEM_CMS: &'static PemGuard = pem_guard!("CMS");
+pub const PEM_CRL: &'static PemGuard = pem_guard!("X509 CRL");
 
 const BASE64_PEM_WRAP: usize = 64;
 

--- a/src/pkcs10.rs
+++ b/src/pkcs10.rs
@@ -48,6 +48,10 @@ impl<I: BERDecodable, A: SignatureAlgorithm + BERDecodable, S: BERDecodable> BER
 }
 
 impl<'a, K, A: SignatureAlgorithm, S> CertificationRequest<CertificationRequestInfo<'a, K>, A, S> {
+    pub fn has_attribute(&self, oid: &ObjectIdentifier) -> bool {
+        self.reqinfo.attributes.iter().any(|a| a.oid == *oid)
+    }
+
     pub fn get_attribute<T: FromDer + HasOid>(&self) -> Option<Vec<T>> {
         let oid = T::oid();
 

--- a/src/pkcs10.rs
+++ b/src/pkcs10.rs
@@ -113,8 +113,8 @@ impl<'e, K: DerWrite> DerWrite for CertificationRequestInfo<'e, K> {
     }
 }
 
-impl<K: BERDecodable> BERDecodable for CertificationRequestInfo<'static, K> {
-    fn decode_ber<'a, 'b>(reader: BERReader<'a, 'b>) -> ASN1Result<Self> {
+impl<'a, K: BERDecodable> BERDecodable for CertificationRequestInfo<'a, K> {
+    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|r| {
             let version = r.next().read_u8()?;
             if version != CERTIFICATION_REQUEST_INFO_V1 {

--- a/src/pkcs10.rs
+++ b/src/pkcs10.rs
@@ -86,6 +86,7 @@ impl<'a, K, A: SignatureAlgorithm, S> CertificationRequest<CertificationRequestI
         }
     }
 }
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct CertificationRequestInfo<'e, K> {
     // version: v1

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -118,3 +118,16 @@ impl DerWrite for TaggedDerValue {
         writer.write_tagged_der(self)
     }
 }
+
+pub trait WriteIa5StringSafe {
+    fn write_ia5_string_safe(self, string: &str);
+}
+
+impl<'a> WriteIa5StringSafe for DERWriter<'a> {
+    fn write_ia5_string_safe(self, string: &str) {
+        // DERWriter::write_ia5_string() panics when the string contains non-ascii characters.
+        // The return type must be (), so the best we can do instead is to filter out non-ascii
+        // characters from the string up front.
+        self.write_ia5_string(&string.replace(|c: char| !c.is_ascii(), ""))
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -103,6 +103,153 @@ impl<'a> GeneralName<'a> {
     const TAG_UNIFORM_RESOURCE_IDENTIFIER: u64 = 6;
     const TAG_IP_ADDRESS: u64 = 7;
     const TAG_REGISTERED_ID: u64 = 8;
+
+    pub fn is_other_name(&self) -> bool {
+        match *self {
+            GeneralName::OtherName(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_other_name(&self) -> Option<(&ObjectIdentifier, &TaggedDerValue)> {
+        match self {
+            GeneralName::OtherName(oid, tdv) => Some((oid, tdv)),
+            _ => None,
+        }
+    }
+
+    pub fn into_other_name(self) -> Option<(ObjectIdentifier, TaggedDerValue)> {
+        match self {
+            GeneralName::OtherName(oid, tdv) => Some((oid, tdv)),
+            _ => None,
+        }
+    }
+
+    pub fn is_rfc822_name(&self) -> bool {
+        match *self {
+            GeneralName::Rfc822Name(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_rfc822_name(&self) -> Option<&Cow<'a, str>> {
+        match self {
+            GeneralName::Rfc822Name(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn into_rfc822_name(self) -> Option<Cow<'a, str>> {
+        match self {
+            GeneralName::Rfc822Name(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn is_dns_name(&self) -> bool {
+        match *self {
+            GeneralName::DnsName(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_dns_name(&self) -> Option<&Cow<'a, str>> {
+        match self {
+            GeneralName::DnsName(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn into_dns_name(self) -> Option<Cow<'a, str>> {
+        match self {
+            GeneralName::DnsName(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn is_directory_name(&self) -> bool {
+        match *self {
+            GeneralName::DirectoryName(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_directory_name(&self) -> Option<&Name> {
+        match self {
+            GeneralName::DirectoryName(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn into_directory_name(self) -> Option<Name> {
+        match self {
+            GeneralName::DirectoryName(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn is_uniform_resource_identifier(&self) -> bool {
+        match *self {
+            GeneralName::UniformResourceIdentifier(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_uniform_resource_identifier(&self) -> Option<&Cow<'a, str>> {
+        match self {
+            GeneralName::UniformResourceIdentifier(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn into_uniform_resource_identifier(self) -> Option<Cow<'a, str>> {
+        match self {
+            GeneralName::UniformResourceIdentifier(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn is_ip_address(&self) -> bool {
+        match *self {
+            GeneralName::IpAddress(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_ip_address(&self) -> Option<&Vec<u8>> {
+        match self {
+            GeneralName::IpAddress(ip) => Some(ip),
+            _ => None,
+        }
+    }
+
+    pub fn into_ip_address(self) -> Option<Vec<u8>> {
+        match self {
+            GeneralName::IpAddress(ip) => Some(ip),
+            _ => None,
+        }
+    }
+
+    pub fn is_registered_id(&self) -> bool {
+        match *self {
+            GeneralName::RegisteredID(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_registered_id(&self) -> Option<&ObjectIdentifier> {
+        match self {
+            GeneralName::RegisteredID(oid) => Some(oid),
+            _ => None,
+        }
+    }
+
+    pub fn into_registered_id(self) -> Option<ObjectIdentifier> {
+        match self {
+            GeneralName::RegisteredID(oid) => Some(oid),
+            _ => None,
+        }
+    }
 }
 
 impl<'a> DerWrite for GeneralName<'a> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -503,6 +503,22 @@ impl From<Vec<u8>> for NameComponent {
     }
 }
 
+impl From<NameComponent> for TaggedDerValue {
+    fn from(nc: NameComponent) -> TaggedDerValue {
+        match nc {
+            NameComponent::Str(str) => TaggedDerValue::from_tag_and_bytes(TAG_UTF8STRING, str.into_bytes()),
+            NameComponent::Bytes(mut val) => {
+                // mbedTLS does not support OCTET STRING in any name component. It does
+                // support BIT STRING, however, so we always use that. The first byte of
+                // a bit string is the number of unused bits. Since we start from a Vec<u8>,
+                // we always have a multiple of 8 bits and hence no bits are unused.
+                val.insert(0, 0);
+                TaggedDerValue::from_tag_and_bytes(TAG_BITSTRING, val)
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Extensions(pub Vec<Extension>);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -410,12 +410,12 @@ impl<'a> DerWrite for Attribute<'a> {
     }
 }
 
-impl BERDecodable for Attribute<'static> {
-    fn decode_ber<'a, 'b>(reader: BERReader<'a, 'b>) -> ASN1Result<Self> {
+impl<'a> BERDecodable for Attribute<'a> {
+    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|seq_reader| {
             let oid = ObjectIdentifier::decode_ber(seq_reader.next())?;
 
-            let mut value = Vec::<DerSequence<'static>>::new();
+            let mut value = Vec::new();
             seq_reader.next().read_set_of(|r| {
                 value.push(DerSequence::decode_ber(r)?);
                 Ok(())
@@ -561,8 +561,8 @@ impl<'a> AsRef<[u8]> for DerSequence<'a> {
     }
 }
 
-impl BERDecodable for DerSequence<'static> {
-    fn decode_ber<'a, 'b>(reader: BERReader<'a, 'b>) -> ASN1Result<Self> {
+impl<'a> BERDecodable for DerSequence<'a> {
+    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         Ok(reader.read_der()?.into())
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,6 +10,7 @@ pub use yasna::models::{ObjectIdentifier, ParseOidError, TaggedDerValue};
 use std::borrow::Cow;
 use std::str;
 use std::fmt;
+use std::ops::{Deref, DerefMut};
 use chrono::{self, Utc, Datelike, Timelike, TimeZone};
 use {DerWrite, FromDer, oid};
 use crate::serialize::WriteIa5StringSafe;
@@ -199,6 +200,32 @@ impl<'a> BERDecodable for GeneralNames<'a> {
     }
 }
 
+impl<'a> Deref for GeneralNames<'a> {
+    type Target = Vec<GeneralName<'a>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> DerefMut for GeneralNames<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a> From<Vec<GeneralName<'a>>> for GeneralNames<'a> {
+    fn from(names: Vec<GeneralName<'a>>) -> GeneralNames<'a> {
+        GeneralNames(names)
+    }
+}
+
+impl<'a> From<GeneralNames<'a>> for Vec<GeneralName<'a>> {
+    fn from(general_names: GeneralNames<'a>) -> Vec<GeneralName<'a>> {
+        general_names.0
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Name {
     // The actual ASN.1 type is Vec<HashSet<(ObjectIdentifier, TaggedDerValue)>>.
@@ -345,6 +372,32 @@ impl DerWrite for Extensions {
 impl BERDecodable for Extensions {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         Ok(Extensions(reader.collect_sequence_of(Extension::decode_ber)?))
+    }
+}
+
+impl Deref for Extensions {
+    type Target = Vec<Extension>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Extensions {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<Vec<Extension>> for Extensions {
+    fn from(extensions: Vec<Extension>) -> Extensions {
+        Extensions(extensions)
+    }
+}
+
+impl From<Extensions> for Vec<Extension> {
+    fn from(extensions: Extensions) -> Vec<Extension> {
+        extensions.0
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -570,14 +570,9 @@ impl BERDecodable for DerSequence<'static> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serialize::DerWrite;
+    use crate::test::test_encode_decode;
     use yasna;
     use yasna::tags::TAG_UTF8STRING;
-
-    fn test_encode_decode<T: DerWrite + BERDecodable + fmt::Debug + PartialEq>(value: &T, expected_der: &[u8]) {
-        assert_eq!(yasna::construct_der(|w| value.write(w)), expected_der);
-        assert_eq!(&yasna::parse_der(expected_der, |r| T::decode_ber(r)).unwrap(), value);
-    }
 
     #[test]
     fn name() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -424,6 +424,11 @@ mod tests {
     use yasna;
     use yasna::tags::TAG_UTF8STRING;
 
+    fn test_encode_decode<T: DerWrite + BERDecodable + fmt::Debug + PartialEq>(value: &T, expected_der: &[u8]) {
+        assert_eq!(yasna::construct_der(|w| value.write(w)), expected_der);
+        assert_eq!(&yasna::parse_der(expected_der, |r| T::decode_ber(r)).unwrap(), value);
+    }
+
     #[test]
     fn name() {
         let name = Name {
@@ -439,9 +444,7 @@ mod tests {
                        0x54, 0x65, 0x73, 0x74, 0x20, 0x6e, 0x61, 0x6d, 0x65, 0x31, 0x19, 0x30, 0x17,
                        0x06, 0x03, 0x55, 0x04, 0x0d, 0x0c, 0x10, 0x54, 0x65, 0x73, 0x74, 0x20, 0x64,
                        0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e];
-
-        assert_eq!(yasna::construct_der(|w| name.write(w)), der);
-        assert_eq!(yasna::parse_der(&der, |r| Name::decode_ber(r)).unwrap(), name);
+        test_encode_decode(&name, &der);
     }
 
     #[test]
@@ -482,8 +485,7 @@ mod tests {
                        0x31, 0x10, 0x04, 0x06, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21, 0x04, 0x06, 0x48,
                        0x65, 0x6c, 0x6c, 0x6f, 0x21];
 
-        assert_eq!(yasna::construct_der(|w| attr.write(w)), der);
-        assert_eq!(yasna::parse_der(&der, |r| Attribute::decode_ber(r)).unwrap(), attr);
+        test_encode_decode(&attr, &der);
     }
 
     #[test]
@@ -493,7 +495,6 @@ mod tests {
         let der = vec![0x17, 0x0d, 0x31, 0x37, 0x30, 0x35, 0x31, 0x39, 0x31, 0x32, 0x33, 0x34,
                        0x35, 0x36, 0x5a];
 
-        assert_eq!(yasna::construct_der(|w| datetime.write(w)), der);
-        assert_eq!(yasna::parse_der(&der, |r| DateTime::decode_ber(r)).unwrap(), datetime);
+        test_encode_decode(&datetime, &der);
     }
 }

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -149,11 +149,13 @@ impl<S: BERDecodable + Integer, A: BERDecodable + SignatureAlgorithm, K: BERDeco
     }
 }
 
+#[deprecated(since="0.1.3", note="use `SubjectAltName` instead")]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct DnsAltNames<'a> {
     pub names: Vec<Cow<'a, str>>,
 }
 
+#[allow(deprecated)]
 impl<'a> DerWrite for DnsAltNames<'a> {
     fn write(&self, writer: DERWriter) {
         writer.write_sequence(|writer| {
@@ -166,6 +168,7 @@ impl<'a> DerWrite for DnsAltNames<'a> {
     }
 }
 
+#[allow(deprecated)]
 impl BERDecodable for DnsAltNames<'static> {
     fn decode_ber<'a, 'b>(reader: BERReader<'a, 'b>) -> ASN1Result<Self> {
         reader.read_sequence(|seq_reader| {
@@ -241,6 +244,7 @@ mod tests {
     use test::test_encode_decode;
 
     #[test]
+    #[allow(deprecated)]
     fn dns_alt_names() {
         let names = DnsAltNames {
             names: vec![

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -169,10 +169,10 @@ impl<'a> DerWrite for DnsAltNames<'a> {
 }
 
 #[allow(deprecated)]
-impl BERDecodable for DnsAltNames<'static> {
-    fn decode_ber<'a, 'b>(reader: BERReader<'a, 'b>) -> ASN1Result<Self> {
+impl<'a> BERDecodable for DnsAltNames<'a> {
+    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|seq_reader| {
-            let mut names = Vec::<Cow<'static, str>>::new();
+            let mut names = Vec::<Cow<'a, str>>::new();
 
             loop {
                 let res = seq_reader.read_optional(|r| {


### PR DESCRIPTION
There is a separate commit for each atomic change made. The intention of this PR is not to change anything in a non-backwards compatible way. Therefore this PR only bumps the patch version of this crate.

A follow-up PR will be made for non-backwards compatible changes. That PR will bump the version to 0.2.0.