### PR TITLE
Add support for non-avx2 platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,12 @@ num-integer = { version = "0.1", default-features = false }
 bit-vec = "0.6"
 lazy_static = "1"
 chrono = "0.4.23"
+
+[target.'cfg(target_feature = "avx2")'.dependencies]
 b64-ct = "0.1.1"
+
+[target.'cfg(not(target_feature = "avx2"))'.dependencies]
+base64 = "0.20.0"
 
 [dev-dependencies]
 rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,10 @@
 
 pub extern crate yasna;
 pub extern crate num_bigint;
+#[cfg(target_feature = "avx2")]
 extern crate b64_ct;
+#[cfg(not(target_feature = "avx2"))]
+extern crate base64;
 extern crate num_integer;
 pub extern crate bit_vec;
 #[macro_use]


### PR DESCRIPTION
Use conditional compilation based on the target_feature to use the base64 crate instead of b64-ct.