### PR TITLE
Refactor with new/updated derive macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ bitflags = "1.3.2"
 
 [dev-dependencies]
 rand = "0.3"
+
+[package.metadata.release]
+tag-prefix = "pkix_"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# pkix
+
+## Release process
+
+1. Create PR to bump the version of `pkix`.
+2. Run `cargo semver-checks` to check whether it's safe to release the new version.
+   1. Please check how to install `cargo-semver-checks` from https://github.com/obi1kenobi/cargo-semver-checks.
+3. Publish package and push new tag through `git tag` and `cargo publish`, please ensure tag name follows `{{crate name}}_v{{version}}`.
+   1. Or you could use `cargo release` to help you, please check how to install `cargo-release` from https://github.com/crate-ci/cargo-release.
+
 # Contributing
 
 We gratefully accept bug reports and contributions from the community.

--- a/src/cmpv2/body.rs
+++ b/src/cmpv2/body.rs
@@ -105,59 +105,59 @@ pub enum PkiBody {
 }
 
 impl PkiBody {
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Initialization Request
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Initialization Request
     const TAG_IR: u64 = 0;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Initialization Response
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Initialization Response
     const TAG_IP: u64 = 1;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Certification Request
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Certification Request
     const TAG_CR: u64 = 2;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Certification Response
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Certification Response
     const TAG_CP: u64 = 3;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for imported from [PKCS10]
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for imported from [PKCS10]
     const TAG_P10_CR: u64 = 4;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for pop Challenge
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for pop Challenge
     const TAG_POP_DE_CC: u64 = 5;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for pop Response
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for pop Response
     const TAG_POP_DE_CR: u64 = 6;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Key Update Request
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Key Update Request
     const TAG_KUR: u64 = 7;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Key Update Response
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Key Update Response
     const TAG_KUP: u64 = 8;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Key Recovery Request
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Key Recovery Request
     const TAG_KRR: u64 = 9;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Key Recovery Response
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Key Recovery Response
     const TAG_KRP: u64 = 10;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Revocation Request
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Revocation Request
     const TAG_RR: u64 = 11;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Revocation Response
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Revocation Response
     const TAG_RP: u64 = 12;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Cross-Cert. Request
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Cross-Cert. Request
     const TAG_CCR: u64 = 13;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Cross-Cert. Response
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Cross-Cert. Response
     const TAG_CCP: u64 = 14;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for CA Key Update Ann.
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for CA Key Update Ann.
     const TAG_CKU_ANN: u64 = 15;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Certificate Ann.
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Certificate Ann.
     const TAG_C_ANN: u64 = 16;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Revocation Ann.
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Revocation Ann.
     const TAG_R_ANN: u64 = 17;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for CRL Announcement
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for CRL Announcement
     const TAG_CRL_ANN: u64 = 18;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Confirmation
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Confirmation
     const TAG_PKI_CONF: u64 = 19;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Nested Message
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Nested Message
     const TAG_NESTED: u64 = 20;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for General Message
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for General Message
     const TAG_GEN_M: u64 = 21;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for General Response
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for General Response
     const TAG_GEN_P: u64 = 22;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Error Message
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Error Message
     const TAG_ERROR: u64 = 23;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Certificate confirm
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Certificate confirm
     const TAG_CERT_CONF: u64 = 24;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Polling request
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Polling request
     const TAG_POLL_REQ: u64 = 25;
-    /// EXPLICIT TAG (rfc4210#appendix-F) for Polling response
+    /// EXPLICIT TAG [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F) for Polling response
     const TAG_POLL_REP: u64 = 26;
 
     fn tag(&self) -> Tag {

--- a/src/cmpv2/body.rs
+++ b/src/cmpv2/body.rs
@@ -56,7 +56,7 @@ pub enum PkiBody {
     Cr(CertReqMessages),
     /// Certification Response
     Cp(CertRepMessage),
-    /// imported from [PKCS10]
+    /// imported from [PKCS10](https://datatracker.ietf.org/doc/html/rfc2986)
     P10cr(CertReq),
     /// pop Challenge
     Popdecc(PopoDecKeyChallContent),

--- a/src/cmpv2/gen.rs
+++ b/src/cmpv2/gen.rs
@@ -7,7 +7,7 @@
 
 //! General purpose message-related types
 
-use crate::types::DerSequence;
+use crate::types::DerAnyOwned;
 
 /// TODO: not implemented yet
-pub type GeneralInfo = DerSequence<'static>;
+pub type GeneralInfo = DerAnyOwned;

--- a/src/cmpv2/gen.rs
+++ b/src/cmpv2/gen.rs
@@ -9,5 +9,5 @@
 
 use crate::types::DerSequence;
 
-/// TODO: fields not needed now are not implemented yet
+/// TODO: not implemented yet
 pub type GeneralInfo = DerSequence<'static>;

--- a/src/cmpv2/header.rs
+++ b/src/cmpv2/header.rs
@@ -57,6 +57,8 @@ derive_sequence! {
     /// ```
     ///
     /// [RFC 4210 Section 5.1.1]: https://datatracker.ietf.org/doc/html/rfc4210#section-5.1.1
+    ///
+    /// Tags are EXPLICIT TAG in default according to [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F).
     PkiHeader<'a> {
         pvno:           [_] UNTAGGED REQUIRED:  Pvno,
         sender:         [_] UNTAGGED REQUIRED:  GeneralName<'a>,

--- a/src/cmpv2/header.rs
+++ b/src/cmpv2/header.rs
@@ -219,5 +219,20 @@ impl<A: SignatureAlgorithm + BERDecodable> BERDecodable for PkiHeader<'_, A> {
     }
 }
 
+define_version! {
+    /// The `PKIHeader` type defined in [RFC 4210 Section 5.1.1] features an inline
+    /// INTEGER definition that is implemented as the Pvno enum.
+    ///
+    /// ```text
+    ///     pvno                INTEGER     { cmp1999(1), cmp2000(2) },
+    /// ```
+    ///
+    /// [RFC 4210 Section 5.1.1]: https://datatracker.ietf.org/doc/html/rfc4210#section-5.1.1
+    Pvno {
+        Cmp1999 = 1,
+        Cmp2000 = 2,
+    }
+}
+
 /// TODO: not implemented yet
 pub type PkiFreeText = DerSequence<'static>;

--- a/src/cmpv2/header.rs
+++ b/src/cmpv2/header.rs
@@ -219,36 +219,5 @@ impl<A: SignatureAlgorithm + BERDecodable> BERDecodable for PkiHeader<'_, A> {
     }
 }
 
-/// The `PKIHeader` type defined in [RFC 4210 Section 5.1.1] features an inline
-/// INTEGER definition that is implemented as the Pvno enum.
-///
-/// ```text
-///     pvno                INTEGER     { cmp1999(1), cmp2000(2) },
-/// ```
-///
-/// [RFC 4210 Section 5.1.1]: https://datatracker.ietf.org/doc/html/rfc4210#section-5.1.1
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub enum Pvno {
-    Cmp1999 = 1,
-    Cmp2000 = 2,
-}
-
-impl DerWrite for Pvno {
-    fn write(&self, writer: DERWriter) {
-        ((*self).clone() as u32).write(writer)
-    }
-}
-
-impl BERDecodable for Pvno {
-    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
-        let num = reader.read_u32()?;
-        match num {
-            1 => Ok(Pvno::Cmp1999),
-            2 => Ok(Pvno::Cmp2000),
-            _ => Err(ASN1Error::new(ASN1ErrorKind::Invalid)),
-        }
-    }
-}
-
-/// TODO: fields not needed now are not implemented yet
+/// TODO: not implemented yet
 pub type PkiFreeText = DerSequence<'static>;

--- a/src/cmpv2/header.rs
+++ b/src/cmpv2/header.rs
@@ -16,206 +16,60 @@ use crate::{
 
 use super::gen::GeneralInfo;
 
-/// The `PKIHeader` type is defined in [RFC 4210 Section 5.1.1].
-///
-/// ```text
-///     PKIHeader ::= SEQUENCE {
-///     pvno                INTEGER     { cmp1999(1), cmp2000(2) },
-///     sender              GeneralName,
-///     -- identifies the sender
-///     recipient           GeneralName,
-///     -- identifies the intended recipient
-///     messageTime     [0] GeneralizedTime         OPTIONAL,
-///     -- time of production of this message (used when sender
-///     -- believes that the transport will be "suitable"; i.e.,
-///     -- that the time will still be meaningful upon receipt)
-///     protectionAlg   [1] AlgorithmIdentifier{ALGORITHM, {...}}
-///     OPTIONAL,
-///     -- algorithm used for calculation of protection bits
-///     senderKID       [2] KeyIdentifier           OPTIONAL,
-///     recipKID        [3] KeyIdentifier           OPTIONAL,
-///     -- to identify specific keys used for protection
-///     transactionID   [4] OCTET STRING            OPTIONAL,
-///     -- identifies the transaction; i.e., this will be the same in
-///     -- corresponding request, response, certConf, and PKIConf
-///     -- messages
-///     senderNonce     [5] OCTET STRING            OPTIONAL,
-///     recipNonce      [6] OCTET STRING            OPTIONAL,
-///     -- nonces used to provide replay protection, senderNonce
-///     -- is inserted by the creator of this message; recipNonce
-///     -- is a nonce previously inserted in a related message by
-///     -- the intended recipient of this message
-///     freeText        [7] PKIFreeText             OPTIONAL,
-///     -- this may be used to indicate context-specific instructions
-///     -- (this field is intended for human consumption)
-///     generalInfo     [8] SEQUENCE SIZE (1..MAX) OF
-///     InfoTypeAndValue     OPTIONAL
-///     -- this may be used to convey context-specific information
-///     -- (this field not primarily intended for human consumption)
-///     }
-/// ```
-///
-/// [RFC 4210 Section 5.1.1]: https://datatracker.ietf.org/doc/html/rfc4210#section-5.1.1
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct PkiHeader<'a> {
-    pub pvno: Pvno,
-    pub sender: GeneralName<'a>,
-    pub recipient: GeneralName<'a>,
-    pub message_time: Option<GeneralizedTime>,
-    pub protection_alg: Option<AlgorithmIdentifierOwned>,
-    pub sender_kid: Option<OctetString>,
-    pub recip_kid: Option<OctetString>,
-    pub trans_id: Option<OctetString>,
-    pub sender_nonce: Option<OctetString>,
-    pub recip_nonce: Option<OctetString>,
-    pub free_text: Option<PkiFreeText>,
-    pub general_info: Option<GeneralInfo>,
-}
-
-impl PkiHeader<'_> {
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_MESSAGE_TIME: u64 = 0;
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_PROTECTION_ALG: u64 = 1;
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_SENDER_KID: u64 = 2;
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_RECIP_KID: u64 = 3;
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_TRANS_ID: u64 = 4;
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_SENDER_NONCE: u64 = 5;
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_RECIP_NONCE: u64 = 6;
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_FREE_TEXT: u64 = 7;
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_GENERAL_INFO: u64 = 8;
-}
-
-impl DerWrite for PkiHeader<'_> {
-    fn write(&self, writer: DERWriter) {
-        writer.write_sequence(|writer| {
-            self.pvno.write(writer.next());
-            self.sender.write(writer.next());
-            self.recipient.write(writer.next());
-            if let Some(message_time) = self.message_time.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_MESSAGE_TIME), |writer| message_time.write(writer))
-            };
-            if let Some(protection_alg) = self.protection_alg.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_PROTECTION_ALG), |writer| protection_alg.write(writer))
-            };
-            if let Some(sender_kid) = self.sender_kid.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_SENDER_KID), |writer| sender_kid.write(writer))
-            };
-            if let Some(recip_kid) = self.recip_kid.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_RECIP_KID), |writer| recip_kid.write(writer))
-            };
-            if let Some(trans_id) = self.trans_id.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_TRANS_ID), |writer| trans_id.write(writer))
-            };
-            if let Some(sender_nonce) = self.sender_nonce.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_SENDER_NONCE), |writer| sender_nonce.write(writer))
-            };
-            if let Some(recip_nonce) = self.recip_nonce.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_RECIP_NONCE), |writer| recip_nonce.write(writer))
-            };
-            if let Some(free_text) = self.free_text.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_FREE_TEXT), |writer| free_text.write(writer))
-            };
-            if let Some(general_info) = self.general_info.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_GENERAL_INFO), |writer| general_info.write(writer))
-            };
-        })
-    }
-}
-
-impl BERDecodable for PkiHeader<'_> {
-    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
-        reader.read_sequence(|reader| {
-            let pvno = <Pvno as BERDecodable>::decode_ber(reader.next())?;
-            let sender = <GeneralName as BERDecodable>::decode_ber(reader.next())?;
-            let recipient = <GeneralName as BERDecodable>::decode_ber(reader.next())?;
-            let message_time: Option<GeneralizedTime> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_MESSAGE_TIME), |reader| {
-                    <GeneralizedTime as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-            let protection_alg: Option<AlgorithmIdentifierOwned> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_PROTECTION_ALG), |reader| {
-                    <AlgorithmIdentifierOwned as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-            let sender_kid: Option<OctetString> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_SENDER_KID), |reader| {
-                    <OctetString as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-
-            let recip_kid: Option<OctetString> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_RECIP_KID), |reader| {
-                    <OctetString as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-            let trans_id: Option<OctetString> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_TRANS_ID), |reader| {
-                    <OctetString as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-            let sender_nonce: Option<OctetString> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_SENDER_NONCE), |reader| {
-                    <OctetString as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-            let recip_nonce: Option<OctetString> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_RECIP_NONCE), |reader| {
-                    <OctetString as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-            let free_text: Option<PkiFreeText> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_FREE_TEXT), |reader| {
-                    <PkiFreeText as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-            let general_info: Option<GeneralInfo> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_GENERAL_INFO), |reader| {
-                    <GeneralInfo as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-
-            Ok(PkiHeader {
-                pvno,
-                sender,
-                recipient,
-                message_time,
-                protection_alg,
-                sender_kid,
-                recip_kid,
-                trans_id,
-                sender_nonce,
-                recip_nonce,
-                free_text,
-                general_info,
-            })
-        })
+derive_sequence! {
+    /// The `PKIHeader` type is defined in [RFC 4210 Section 5.1.1].
+    ///
+    /// ```text
+    ///     PKIHeader ::= SEQUENCE {
+    ///     pvno                INTEGER     { cmp1999(1), cmp2000(2) },
+    ///     sender              GeneralName,
+    ///     -- identifies the sender
+    ///     recipient           GeneralName,
+    ///     -- identifies the intended recipient
+    ///     messageTime     [0] GeneralizedTime         OPTIONAL,
+    ///     -- time of production of this message (used when sender
+    ///     -- believes that the transport will be "suitable"; i.e.,
+    ///     -- that the time will still be meaningful upon receipt)
+    ///     protectionAlg   [1] AlgorithmIdentifier{ALGORITHM, {...}}
+    ///     OPTIONAL,
+    ///     -- algorithm used for calculation of protection bits
+    ///     senderKID       [2] KeyIdentifier           OPTIONAL,
+    ///     recipKID        [3] KeyIdentifier           OPTIONAL,
+    ///     -- to identify specific keys used for protection
+    ///     transactionID   [4] OCTET STRING            OPTIONAL,
+    ///     -- identifies the transaction; i.e., this will be the same in
+    ///     -- corresponding request, response, certConf, and PKIConf
+    ///     -- messages
+    ///     senderNonce     [5] OCTET STRING            OPTIONAL,
+    ///     recipNonce      [6] OCTET STRING            OPTIONAL,
+    ///     -- nonces used to provide replay protection, senderNonce
+    ///     -- is inserted by the creator of this message; recipNonce
+    ///     -- is a nonce previously inserted in a related message by
+    ///     -- the intended recipient of this message
+    ///     freeText        [7] PKIFreeText             OPTIONAL,
+    ///     -- this may be used to indicate context-specific instructions
+    ///     -- (this field is intended for human consumption)
+    ///     generalInfo     [8] SEQUENCE SIZE (1..MAX) OF
+    ///     InfoTypeAndValue     OPTIONAL
+    ///     -- this may be used to convey context-specific information
+    ///     -- (this field not primarily intended for human consumption)
+    ///     }
+    /// ```
+    ///
+    /// [RFC 4210 Section 5.1.1]: https://datatracker.ietf.org/doc/html/rfc4210#section-5.1.1
+    PkiHeader<'a> {
+        pvno:           [_] UNTAGGED REQUIRED:  Pvno,
+        sender:         [_] UNTAGGED REQUIRED:  GeneralName<'a>,
+        recipient:      [_] UNTAGGED REQUIRED:  GeneralName<'a>,
+        message_time:   [0] EXPLICIT OPTIONAL:  Option<GeneralizedTime>,
+        protection_alg: [1] EXPLICIT OPTIONAL:  Option<AlgorithmIdentifierOwned>,
+        sender_kid:     [2] EXPLICIT OPTIONAL:  Option<OctetString>,
+        recip_kid:      [3] EXPLICIT OPTIONAL:  Option<OctetString>,
+        trans_id:       [4] EXPLICIT OPTIONAL:  Option<OctetString>,
+        sender_nonce:   [5] EXPLICIT OPTIONAL:  Option<OctetString>,
+        recip_nonce:    [6] EXPLICIT OPTIONAL:  Option<OctetString>,
+        free_text:      [7] EXPLICIT OPTIONAL:  Option<PkiFreeText>,
+        general_info:   [8] EXPLICIT OPTIONAL:  Option<GeneralInfo>,
     }
 }
 

--- a/src/cmpv2/message.rs
+++ b/src/cmpv2/message.rs
@@ -14,74 +14,24 @@ use crate::{x509::GenericCertificate, DerWrite};
 
 use super::{body::PkiBody, header::PkiHeader};
 
-/// The `PKIMessage` type is defined in [RFC 4210 Section 5.1].
-///
-/// ```text
-/// PKIMessage ::= SEQUENCE {
-///     header           PKIHeader,
-///     body             PKIBody,
-///     protection   [0] PKIProtection OPTIONAL,
-///     extraCerts   [1] SEQUENCE SIZE (1..MAX) OF CMPCertificate
-///     OPTIONAL }
-/// ```
-///
-/// [RFC 4210 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc4210#section-5.1
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct PkiMessage<'a> {
-    pub header: PkiHeader<'a>,
-    pub body: PkiBody,
-    pub protection: Option<PkiProtection>,
-    pub extra_certs: Option<CmpCertificates>,
-}
-
-impl PkiMessage<'_> {
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_PROTECTION: u64 = 0;
-    /// EXPLICIT TAG (rfc4210#appendix-F)
-    const TAG_EXTRA_CERTS: u64 = 1;
-}
-
-impl DerWrite for PkiMessage<'_> {
-    fn write(&self, writer: DERWriter) {
-        writer.write_sequence(|writer| {
-            self.header.write(writer.next());
-            self.body.write(writer.next());
-            if let Some(protection) = self.protection.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_PROTECTION), |writer| protection.write(writer))
-            };
-            if let Some(extra_certs) = self.extra_certs.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_EXTRA_CERTS), |writer| extra_certs.write(writer))
-            };
-        })
-    }
-}
-
-impl BERDecodable for PkiMessage<'_> {
-    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
-        reader.read_sequence(|reader| {
-            let header = <PkiHeader as BERDecodable>::decode_ber(reader.next())?;
-            let body = <PkiBody as BERDecodable>::decode_ber(reader.next())?;
-            let protection: Option<PkiProtection> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_PROTECTION), |reader| {
-                    <PkiProtection as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-            let extra_certs: Option<CmpCertificates> = reader.read_optional(|reader| {
-                reader.read_tagged(Tag::context(Self::TAG_EXTRA_CERTS), |reader| {
-                    <CmpCertificates as BERDecodable>::decode_ber(reader)
-                })
-            })?;
-            Ok(PkiMessage {
-                header,
-                body,
-                protection,
-                extra_certs,
-            })
-        })
+derive_sequence! {
+    /// The `PKIMessage` type is defined in [RFC 4210 Section 5.1].
+    ///
+    /// ```text
+    /// PKIMessage ::= SEQUENCE {
+    ///     header           PKIHeader,
+    ///     body             PKIBody,
+    ///     protection   [0] PKIProtection OPTIONAL,
+    ///     extraCerts   [1] SEQUENCE SIZE (1..MAX) OF CMPCertificate
+    ///     OPTIONAL }
+    /// ```
+    ///
+    /// [RFC 4210 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc4210#section-5.1
+    PkiMessage<'a> {
+        header:      [_] UNTAGGED REQUIRED: PkiHeader<'a>,
+        body:        [_] UNTAGGED REQUIRED: PkiBody,
+        protection:  [0] EXPLICIT OPTIONAL: Option<PkiProtection>,
+        extra_certs: [1] EXPLICIT OPTIONAL: Option<CmpCertificates>,
     }
 }
 
@@ -103,59 +53,27 @@ pub type PkiProtection = BitVec;
 /// [RFC 4210 Appendix F]: https://www.rfc-editor.org/rfc/rfc4210#appendix-F
 pub type CmpCertificate = GenericCertificate;
 
-/// Represents: SEQUENCE SIZE (1..MAX) OF CMPCertificate
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct CmpCertificates(pub Vec<CmpCertificate>);
+derive_sequence_of!{
+    /// Represents: SEQUENCE SIZE (1..MAX) OF CMPCertificate
+    CmpCertificate => CmpCertificates
+}
 
-impl DerWrite for CmpCertificates {
-    fn write(&self, writer: DERWriter) {
-        writer.write_sequence_of(|w| {
-            for cert in &self.0 {
-                cert.write(w.next())
-            }
-        })
+derive_sequence! {
+    /// The `ProtectedPart` type is defined in [RFC 4210 Section 5.1.3].
+    ///
+    /// ```text
+    /// ProtectedPart ::= SEQUENCE {
+    ///     header    PKIHeader,
+    ///     body      PKIBody }
+    /// ```
+    ///
+    /// [RFC 4210 Section 5.1.3]: https://www.rfc-editor.org/rfc/rfc4210#section-5.1.3
+    ProtectedPart<'a> {
+        header:      PkiHeader<'a>,
+        body:        PkiBody,
     }
 }
 
-impl BERDecodable for CmpCertificates {
-    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
-        Ok(CmpCertificates(reader.collect_sequence_of(CmpCertificate::decode_ber)?))
-    }
-}
-
-/// The `ProtectedPart` type is defined in [RFC 4210 Section 5.1.3].
-///
-/// ```text
-/// ProtectedPart ::= SEQUENCE {
-///     header    PKIHeader,
-///     body      PKIBody }
-/// ```
-///
-/// [RFC 4210 Section 5.1.3]: https://www.rfc-editor.org/rfc/rfc4210#section-5.1.3
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct ProtectedPart<'a> {
-    pub header: PkiHeader<'a>,
-    pub body: PkiBody,
-}
-
-impl DerWrite for ProtectedPart<'_> {
-    fn write(&self, writer: DERWriter) {
-        writer.write_sequence(|w| {
-            self.header.write(w.next());
-            self.body.write(w.next());
-        });
-    }
-}
-
-impl BERDecodable for ProtectedPart<'_> {
-    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
-        reader.read_sequence(|r| {
-            let header = PkiHeader::decode_ber(r.next())?;
-            let body = PkiBody::decode_ber(r.next())?;
-            Ok(ProtectedPart { header, body })
-        })
-    }
-}
 
 #[cfg(test)]
 mod test {

--- a/src/cmpv2/message.rs
+++ b/src/cmpv2/message.rs
@@ -27,6 +27,8 @@ derive_sequence! {
     /// ```
     ///
     /// [RFC 4210 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc4210#section-5.1
+    ///
+    /// Tags are EXPLICIT TAG in default according to [rfc4210#appendix-F](https://datatracker.ietf.org/doc/html/rfc4210#appendix-F).
     PkiMessage<'a> {
         header:      [_] UNTAGGED REQUIRED: PkiHeader<'a>,
         body:        [_] UNTAGGED REQUIRED: PkiBody,

--- a/src/crmf/controls.rs
+++ b/src/crmf/controls.rs
@@ -11,29 +11,14 @@ use yasna::{ASN1Result, BERDecodable, BERReader, DERWriter};
 
 use crate::{x509::AttributeTypeAndValue, DerWrite};
 
-/// The `Controls` type is defined in [RFC 4211 Section 6].
-///
-/// ```text
-///   Controls  ::= SEQUENCE SIZE(1..MAX) OF SingleAttribute
-///                     {{RegControlSet}}
-/// ```
-///
-/// [RFC 4211 Section 6]: https://www.rfc-editor.org/rfc/rfc4211#section-6
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct Controls(pub Vec<AttributeTypeAndValue>);
-
-impl DerWrite for Controls {
-    fn write(&self, writer: DERWriter) {
-        writer.write_sequence_of(|w| {
-            for control in &self.0 {
-                control.write(w.next())
-            }
-        });
-    }
-}
-
-impl BERDecodable for Controls {
-    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
-        Ok(Controls(reader.collect_sequence_of(AttributeTypeAndValue::decode_ber)?))
-    }
+derive_sequence_of!{
+    /// The `Controls` type is defined in [RFC 4211 Section 6].
+    ///
+    /// ```text
+    ///   Controls  ::= SEQUENCE SIZE(1..MAX) OF SingleAttribute
+    ///                     {{RegControlSet}}
+    /// ```
+    ///
+    /// [RFC 4211 Section 6]: https://www.rfc-editor.org/rfc/rfc4211#section-6
+    AttributeTypeAndValue => Controls
 }

--- a/src/crmf/pop.rs
+++ b/src/crmf/pop.rs
@@ -165,5 +165,5 @@ impl<A: SignatureAlgorithm + BERDecodable> BERDecodable for PopoSigningKey<A> {
 /// ```
 ///
 /// [RFC 4211 Section 4.1]: https://www.rfc-editor.org/rfc/rfc4211#section-4.1
-/// TODO: fields not needed now are not implemented yet
+/// TODO: not implemented yet
 pub type PopoSigningKeyInput = DerSequence<'static>;

--- a/src/crmf/pop.rs
+++ b/src/crmf/pop.rs
@@ -37,13 +37,13 @@ pub enum ProofOfPossession {
 }
 
 impl ProofOfPossession {
-    /// IMPLICIT TAG (rfc4211#appendix-B) for RaVerified
+    /// IMPLICIT TAG [RFC4211#appendix-B](https://datatracker.ietf.org/doc/html/rfc4211#appendix-B) for RaVerified
     const TAG_RA_VERIFIED: u64 = 0;
-    /// IMPLICIT TAG (rfc4211#appendix-B) for Signature
+    /// IMPLICIT TAG [RFC4211#appendix-B](https://datatracker.ietf.org/doc/html/rfc4211#appendix-B) for Signature
     const TAG_SIGNATURE: u64 = 1;
-    /// IMPLICIT TAG (rfc4211#appendix-B) for KeyEncipherment
+    /// IMPLICIT TAG [RFC4211#appendix-B](https://datatracker.ietf.org/doc/html/rfc4211#appendix-B) for KeyEncipherment
     const TAG_KEY_ENCIPHERMENT: u64 = 2;
-    /// IMPLICIT TAG (rfc4211#appendix-B) for KeyAgreement
+    /// IMPLICIT TAG [RFC4211#appendix-B](https://datatracker.ietf.org/doc/html/rfc4211#appendix-B) for KeyAgreement
     const TAG_KEY_AGREEMENT: u64 = 3;
 
     fn tag(&self) -> Tag {
@@ -114,7 +114,7 @@ pub struct PopoSigningKey {
 }
 
 impl PopoSigningKey {
-    /// IMPLICIT TAG (rfc4211#appendix-B)
+    /// IMPLICIT TAG [RFC4211#appendix-B](https://datatracker.ietf.org/doc/html/rfc4211#appendix-B) for POPOSigningKeyInput
     const TAG_POPOSK_INPUT: u64 = 0;
 }
 

--- a/src/crmf/request.rs
+++ b/src/crmf/request.rs
@@ -99,7 +99,8 @@ derive_sequence! {
     ///
     /// [RFC 4211 Section 5]: https://www.rfc-editor.org/rfc/rfc4211#section-5
     ///
-    /// Note: `issuer` and `subject` are EXPLICIT tagged, because they are type of CHOICE
+    /// Tags are IMPLICIT TAG according to [RFC4211#appendix-B](https://datatracker.ietf.org/doc/html/rfc4211#appendix-B),
+    /// but `issuer` and `subject` are EXPLICIT tagged because they are ASN.1 type of `CHOICE`.
     CertTemplate {
         version:                 [0] IMPLICIT OPTIONAL: Option<Version>,
         serial_number:           [1] IMPLICIT OPTIONAL: Option<SerialNumber>,

--- a/src/crmf/request.rs
+++ b/src/crmf/request.rs
@@ -79,171 +79,42 @@ derive_sequence_of!{
     Attribute<'static> => AttributeSeq
 }
 
-/// The `CertTemplate` type is defined in [RFC 4211 Section 5].
-///
-/// ```text
-///   CertTemplate ::= SEQUENCE {
-///       version      [0] Version               OPTIONAL,
-///       serialNumber [1] INTEGER               OPTIONAL,
-///       signingAlg   [2] AlgorithmIdentifier{SIGNATURE-ALGORITHM,
-///                            {SignatureAlgorithms}}   OPTIONAL,
-///       issuer       [3] Name                  OPTIONAL,
-///       validity     [4] OptionalValidity      OPTIONAL,
-///       subject      [5] Name                  OPTIONAL,
-///       publicKey    [6] SubjectPublicKeyInfo  OPTIONAL,
-///       issuerUID    [7] UniqueIdentifier      OPTIONAL,
-///       subjectUID   [8] UniqueIdentifier      OPTIONAL,
-///       extensions   [9] Extensions{{CertExtensions}}  OPTIONAL }
-/// ```
-///
-/// [RFC 4211 Section 5]: https://www.rfc-editor.org/rfc/rfc4211#section-5
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct CertTemplate {
-    pub version: Option<Version>,
-    pub serial_number: Option<SerialNumber>,
-    pub signing_alg: Option<AlgorithmIdentifierOwned>,
-    pub issuer: Option<Name>,
-    pub validity: Option<Validity>,
-    pub subject: Option<Name>,
-    pub subject_public_key_info: Option<SubjectPublicKeyInfo>,
-    pub issuer_unique_id: Option<BitVec>,
-    pub subject_unique_id: Option<BitVec>,
-    pub extensions: Option<Extensions>,
+derive_sequence! {
+    /// The `CertTemplate` type is defined in [RFC 4211 Section 5].
+    ///
+    /// ```text
+    ///   CertTemplate ::= SEQUENCE {
+    ///       version      [0] Version               OPTIONAL,
+    ///       serialNumber [1] INTEGER               OPTIONAL,
+    ///       signingAlg   [2] AlgorithmIdentifier{SIGNATURE-ALGORITHM,
+    ///                            {SignatureAlgorithms}}   OPTIONAL,
+    ///       issuer       [3] Name                  OPTIONAL,
+    ///       validity     [4] OptionalValidity      OPTIONAL,
+    ///       subject      [5] Name                  OPTIONAL,
+    ///       publicKey    [6] SubjectPublicKeyInfo  OPTIONAL,
+    ///       issuerUID    [7] UniqueIdentifier      OPTIONAL,
+    ///       subjectUID   [8] UniqueIdentifier      OPTIONAL,
+    ///       extensions   [9] Extensions{{CertExtensions}}  OPTIONAL }
+    /// ```
+    ///
+    /// [RFC 4211 Section 5]: https://www.rfc-editor.org/rfc/rfc4211#section-5
+    ///
+    /// Note: `issuer` and `subject` are EXPLICIT tagged, because they are type of CHOICE
+    CertTemplate {
+        version:                 [0] IMPLICIT OPTIONAL: Option<Version>,
+        serial_number:           [1] IMPLICIT OPTIONAL: Option<SerialNumber>,
+        signing_alg:             [2] IMPLICIT OPTIONAL: Option<AlgorithmIdentifierOwned>,
+        issuer:                  [3] EXPLICIT OPTIONAL: Option<Name>,
+        validity:                [4] IMPLICIT OPTIONAL: Option<Validity>,
+        subject:                 [5] EXPLICIT OPTIONAL: Option<Name>,
+        subject_public_key_info: [6] IMPLICIT OPTIONAL: Option<SubjectPublicKeyInfo>,
+        issuer_unique_id:        [7] IMPLICIT OPTIONAL: Option<BitVec>,
+        subject_unique_id:       [8] IMPLICIT OPTIONAL: Option<BitVec>,
+        extensions:              [9] IMPLICIT OPTIONAL: Option<Extensions>,
+    }
 }
 
 /// TODO: fields not needed now are not fully implemented
 pub type SerialNumber = BigUint;
 /// TODO: fields not needed now are not fully implemented
 pub type Validity = DerAnyOwned;
-
-impl CertTemplate {
-    /// IMPLICIT TAG (rfc4211#appendix-B)
-    const TAG_VERSION: u64 = 0;
-    /// IMPLICIT TAG (rfc4211#appendix-B)
-    const TAG_SERIAL_NUMBER: u64 = 1;
-    /// IMPLICIT TAG (rfc4211#appendix-B)
-    const TAG_SIGNING_ALG: u64 = 2;
-    /// EXPLICIT TAG, because issuer is type of NAME which is a CHOICE
-    const TAG_ISSUER: u64 = 3;
-    /// IMPLICIT TAG (rfc4211#appendix-B)
-    const TAG_VALIDITY: u64 = 4;
-    /// EXPLICIT TAG, because subject is type of NAME which is a CHOICE
-    const TAG_SUBJECT: u64 = 5;
-    /// IMPLICIT TAG (rfc4211#appendix-B)
-    const TAG_SUBJECT_PUBLIC_KEY_INFO: u64 = 6;
-    /// IMPLICIT TAG (rfc4211#appendix-B)
-    const TAG_ISSUER_UNIQUE_ID: u64 = 7;
-    /// IMPLICIT TAG (rfc4211#appendix-B)
-    const TAG_SUBJECT_UNIQUE_ID: u64 = 8;
-    /// IMPLICIT TAG (rfc4211#appendix-B)
-    const TAG_EXTENSIONS: u64 = 9;
-}
-
-impl DerWrite for CertTemplate {
-    fn write(&self, writer: DERWriter) {
-        writer.write_sequence(|writer| {
-            if let Some(version) = self.version.as_ref() {
-                writer
-                    .next()
-                    .write_tagged_implicit(Tag::context(Self::TAG_VERSION), |w| version.write(w))
-            };
-            if let Some(serial_number) = self.serial_number.as_ref() {
-                writer
-                    .next()
-                    .write_tagged_implicit(Tag::context(Self::TAG_SERIAL_NUMBER), |w| serial_number.write(w))
-            };
-            if let Some(signature) = self.signing_alg.as_ref() {
-                writer
-                    .next()
-                    .write_tagged_implicit(Tag::context(Self::TAG_SIGNING_ALG), |w| signature.write(w))
-            };
-            if let Some(issuer) = self.issuer.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_ISSUER), |w| issuer.write(w))
-            };
-            if let Some(validity) = self.validity.as_ref() {
-                writer
-                    .next()
-                    .write_tagged_implicit(Tag::context(Self::TAG_VALIDITY), |w| validity.write(w))
-            };
-            if let Some(subject) = self.subject.as_ref() {
-                writer
-                    .next()
-                    .write_tagged(Tag::context(Self::TAG_SUBJECT), |w| subject.write(w))
-            };
-            if let Some(spki) = self.subject_public_key_info.as_ref() {
-                writer
-                    .next()
-                    .write_tagged_implicit(Tag::context(Self::TAG_SUBJECT_PUBLIC_KEY_INFO), |w| spki.write(w))
-            };
-
-            if let Some(issuer_unique_id) = self.issuer_unique_id.as_ref() {
-                writer
-                    .next()
-                    .write_tagged_implicit(Tag::context(Self::TAG_ISSUER_UNIQUE_ID), |w| issuer_unique_id.write(w))
-            };
-            if let Some(subject_unique_id) = self.subject_unique_id.as_ref() {
-                writer
-                    .next()
-                    .write_tagged_implicit(Tag::context(Self::TAG_SUBJECT_UNIQUE_ID), |w| subject_unique_id.write(w))
-            };
-            if let Some(extensions) = self.extensions.as_ref() {
-                writer
-                    .next()
-                    .write_tagged_implicit(Tag::context(Self::TAG_EXTENSIONS), |w| extensions.write(w))
-            };
-        });
-    }
-}
-impl BERDecodable for CertTemplate {
-    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
-        reader.read_sequence(|reader| {
-            let version = reader.read_optional(|r| {
-                r.read_tagged_implicit(Tag::context(Self::TAG_VERSION), |reader| Version::decode_ber(reader))
-            })?;
-            let serial_number = reader.read_optional(|r| {
-                r.read_tagged_implicit(Tag::context(Self::TAG_SERIAL_NUMBER), |reader| {
-                    SerialNumber::decode_ber(reader)
-                })
-            })?;
-            let signing_alg = reader
-                .read_optional(|r| r.read_tagged_implicit(Tag::context(Self::TAG_SIGNING_ALG), |reader| AlgorithmIdentifierOwned::decode_ber(reader)))?;
-            let issuer =
-                reader.read_optional(|r| r.read_tagged(Tag::context(Self::TAG_ISSUER), |reader| Name::decode_ber(reader)))?;
-            let validity = reader.read_optional(|r| {
-                r.read_tagged_implicit(Tag::context(Self::TAG_VALIDITY), |reader| Validity::decode_ber(reader))
-            })?;
-
-            let subject =
-                reader.read_optional(|r| r.read_tagged(Tag::context(Self::TAG_SUBJECT), |reader| Name::decode_ber(reader)))?;
-            let subject_public_key_info = reader.read_optional(|r| {
-                r.read_tagged_implicit(Tag::context(Self::TAG_SUBJECT_PUBLIC_KEY_INFO), |reader| {
-                    SubjectPublicKeyInfo::decode_ber(reader)
-                })
-            })?;
-
-            let issuer_unique_id = reader.read_optional(|r| {
-                r.read_tagged_implicit(Tag::context(Self::TAG_ISSUER_UNIQUE_ID), |reader| BitVec::decode_ber(reader))
-            })?;
-            let subject_unique_id = reader.read_optional(|r| {
-                r.read_tagged_implicit(Tag::context(Self::TAG_SUBJECT_UNIQUE_ID), |reader| BitVec::decode_ber(reader))
-            })?;
-            let extensions = reader.read_optional(|r| {
-                r.read_tagged_implicit(Tag::context(Self::TAG_EXTENSIONS), |reader| Extensions::decode_ber(reader))
-            })?;
-            Ok(CertTemplate {
-                version,
-                serial_number,
-                signing_alg,
-                issuer,
-                validity,
-                subject,
-                subject_public_key_info,
-                issuer_unique_id,
-                subject_unique_id,
-                extensions,
-            })
-        })
-    }
-}

--- a/src/crmf/request.rs
+++ b/src/crmf/request.rs
@@ -111,9 +111,9 @@ pub struct CertTemplate {
     pub extensions: Option<Extensions>,
 }
 
-/// TODO: fields not needed now are not fully implemented, track ticket:
+/// TODO: fields not needed now are not fully implemented
 pub type SerialNumber = BigUint;
-/// TODO: fields not needed now are not fully implemented, track ticket:
+/// TODO: fields not needed now are not fully implemented
 pub type Validity = DerAnyOwned;
 
 impl CertTemplate {

--- a/src/derives.rs
+++ b/src/derives.rs
@@ -399,9 +399,12 @@ macro_rules! derive_set_of {
 
 #[macro_export]
 macro_rules! derive_sequence {
-    ($name:ident {
+    (
+        $(#[$outer:meta])*
+        $name:ident {
          $($item:ident : [$tag:tt] $tag_type:ident $optional:ident: $item_type:ty),*$(,)*
     }) => {
+        $(#[$outer])*
         #[derive(Clone, Debug, Eq, PartialEq, Hash)]
         #[allow(non_camel_case_types, non_snake_case)]
         pub struct $name {
@@ -436,29 +439,38 @@ macro_rules! derive_sequence {
         }
     };
 
-    ($name:ident {
+    (
+        $(#[$outer:meta])*
+        $name:ident {
         $($item:ident : [$tag:tt] $tag_type:ident : $item_type:ty),*$(,)*
     }) => {
             derive_sequence! {
+                $(#[$outer])*
                 $name {
                     $($item : [$tag] $tag_type REQUIRED : $item_type),*,
                 }
             }
     };
 
-    ($name:ident {
+    (
+        $(#[$outer:meta])*
+        $name:ident {
          $($item:ident : $item_type:ty),*$(,)*
     }) => {
-          derive_sequence! {
-              $name {
-                  $($item : [_] UNTAGGED REQUIRED : $item_type),*,
-              }
-          }
+            derive_sequence! {
+                $(#[$outer])*
+                $name {
+                    $($item : [_] UNTAGGED REQUIRED : $item_type),*,
+                }
+            }
     };
 
-    ($name:ident : Subsequence {
+    (
+        $(#[$outer:meta])*
+        $name:ident : Subsequence {
          $($item:ident : [$tag:tt] $tag_type:ident $optional:ident : $item_type:ty),*$(,)*
     }) => {
+        $(#[$outer])*
         #[derive(Clone, Debug, Eq, PartialEq, Hash)]
         #[allow(non_camel_case_types, non_snake_case)]
         pub struct $name {
@@ -489,23 +501,29 @@ macro_rules! derive_sequence {
         }
     };
 
-    ($name:ident : Subsequence {
+    (
+        $(#[$outer:meta])*
+        $name:ident : Subsequence {
         $($item:ident : [$tag:tt] $tag_type:ident : $item_type:ty),*$(,)*
     }) => {
             derive_sequence! {
+                $(#[$outer])*
                 $name :Subsequence {
                     $($item : [$tag] $tag_type REQUIRED : $item_type),*,
                 }
             }
     };
 
-    ($name:ident : Subsequence {
+    (
+        $(#[$outer:meta])*
+        $name:ident : Subsequence {
          $($item:ident : $item_type:ty),*$(,)*
     }) => {
           derive_sequence! {
-              $name :Subsequence {
-                  $($item : [_] UNTAGGED REQUIRED : $item_type),*,
-              }
+                $(#[$outer])*
+                $name :Subsequence {
+                    $($item : [_] UNTAGGED REQUIRED : $item_type),*,
+                }
           }
     };
 

--- a/src/derives.rs
+++ b/src/derives.rs
@@ -399,7 +399,7 @@ macro_rules! derive_set_of {
 
 #[macro_export]
 macro_rules! derive_sequence_of {
-    ($(#[$outer:meta])* $elem_name:ty => $sequence_name:ident) => {
+    ($(#[$outer:meta])* $elem_name:ty => $sequence_name:ty) => {
         $(#[$outer])*
         #[derive(Clone, Debug, Eq, PartialEq, Hash, Default)]
         #[allow(non_camel_case_types, non_snake_case)]

--- a/src/derives.rs
+++ b/src/derives.rs
@@ -759,9 +759,12 @@ macro_rules! derive_sequence {
 
 #[macro_export]
 macro_rules! define_version {
-    ($name:ident {
+    (
+        $(#[$outer:meta])*
+        $name:ident {
         $($ver:ident = $n:expr),*,
     }) => {
+        $(#[$outer])*
         #[derive(Clone, Debug, Eq, PartialEq, Hash)]
         pub enum $name {
             $($ver = $n),*,

--- a/src/derives.rs
+++ b/src/derives.rs
@@ -442,17 +442,17 @@ macro_rules! derive_sequence_of {
 macro_rules! derive_sequence {
     (
         $(#[$outer:meta])*
-        $name:ident {
+        $name:ident$(<$name_lt:lifetime>)? {
          $($item:ident : [$tag:tt] $tag_type:ident $optional:ident: $item_type:ty),*$(,)*
     }) => {
         $(#[$outer])*
         #[derive(Clone, Debug, Eq, PartialEq, Hash)]
         #[allow(non_camel_case_types, non_snake_case)]
-        pub struct $name {
+        pub struct $name$(<$name_lt>)? {
             $(pub $item : $item_type),*,
         }
 
-        impl DerWrite for $name {
+        impl$(<$name_lt>)? DerWrite for $name$(<$name_lt>)? {
             fn write(&self, writer: DERWriter) {
                 writer.write_sequence(|writer| {
                     derive_sequence! {
@@ -463,7 +463,7 @@ macro_rules! derive_sequence {
                 })
              }
         }
-        impl BERDecodable for $name {
+        impl$(<$name_lt>)? BERDecodable for $name$(<$name_lt>)? {
             fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
                 reader.read_sequence(|reader| {
                     derive_sequence! {
@@ -482,12 +482,12 @@ macro_rules! derive_sequence {
 
     (
         $(#[$outer:meta])*
-        $name:ident {
+        $name:ident$(<$name_lt:lifetime>)? {
         $($item:ident : [$tag:tt] $tag_type:ident : $item_type:ty),*$(,)*
     }) => {
             derive_sequence! {
                 $(#[$outer])*
-                $name {
+                $name$(<$name_lt>)? {
                     $($item : [$tag] $tag_type REQUIRED : $item_type),*,
                 }
             }
@@ -495,12 +495,12 @@ macro_rules! derive_sequence {
 
     (
         $(#[$outer:meta])*
-        $name:ident {
+        $name:ident$(<$name_lt:lifetime>)? {
          $($item:ident : $item_type:ty),*$(,)*
     }) => {
             derive_sequence! {
                 $(#[$outer])*
-                $name {
+                $name$(<$name_lt>)? {
                     $($item : [_] UNTAGGED REQUIRED : $item_type),*,
                 }
             }

--- a/src/derives.rs
+++ b/src/derives.rs
@@ -625,7 +625,7 @@ macro_rules! derive_sequence {
                 }
     };
 
-  ($name:ident deriveDerWr($written:ident, $writer:expr) {
+    ($name:ident deriveDerWr($written:ident, $writer:expr) {
         $item:ident : [$tag:tt] IMPLICIT OPTIONAL : $item_type:ty,
         $($tail:tt)*
     }) => {
@@ -641,7 +641,7 @@ macro_rules! derive_sequence {
                 }
     };
 
-  ($name:ident deriveDerWr($written:ident, $writer:expr) {
+    ($name:ident deriveDerWr($written:ident, $writer:expr) {
         $item:ident : [$tag:tt] UNTAGGED OPTIONAL : $item_type:ty,
         $($tail:tt)*
     }) => {

--- a/src/derives.rs
+++ b/src/derives.rs
@@ -399,42 +399,40 @@ macro_rules! derive_set_of {
 
 #[macro_export]
 macro_rules! derive_sequence_of {
-    ($(#[$outer:meta])* $elem_name:ty => $sequence_name:ty) => {
+    ($(#[$outer:meta])* $elem_name:ident$(<$ele_lt:lifetime>)? => $sequence_name:ident$(<$seq_lt:lifetime>)?) => {
         $(#[$outer])*
         #[derive(Clone, Debug, Eq, PartialEq, Hash, Default)]
         #[allow(non_camel_case_types, non_snake_case)]
-        pub struct $sequence_name {
-            pub elements: Vec<$elem_name>,
-        }
-        impl DerWrite for $sequence_name {
+        pub struct $sequence_name$(<$seq_lt>)?(pub Vec<$elem_name$(<$ele_lt>)?>);
+        impl$(<$seq_lt>)? DerWrite for $sequence_name$(<$seq_lt>)? {
             fn write(&self, writer: DERWriter) {
                 writer.write_sequence_of(|w| {
-                    for element in &self.elements {
+                    for element in &self.0 {
                         element.write(w.next());
                     }
                 })
             }
         }
 
-        impl BERDecodable for $sequence_name {
+        impl$(<$seq_lt>)? BERDecodable for $sequence_name$(<$seq_lt>)? {
             fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
                 Ok($sequence_name(reader.collect_sequence_of($elem_name::decode_ber)?))
             }
         }
-        impl From<Vec<$elem_name>> for $sequence_name {
-            fn from(elements: Vec<$elem_name>) -> $sequence_name {
-                $sequence_name { elements }
+        impl$(<$seq_lt>)? From<Vec<$elem_name$(<$ele_lt>)?>> for $sequence_name$(<$seq_lt>)? {
+            fn from(elements: Vec<$elem_name$(<$ele_lt>)?>) -> Self {
+                Self(elements)
             }
         }
-        impl $sequence_name {
+        impl$(<$seq_lt>)? $sequence_name$(<$seq_lt>)? {
             #[allow(unused)]
-            pub fn push<T: Into<$elem_name>>(&mut self, elem: T) {
-                self.elements.push(elem.into());
+            pub fn push<T: Into<$elem_name$(<$ele_lt>)?>>(&mut self, elem: T) {
+                self.0.push(elem.into());
             }
         }
-        impl From<$sequence_name> for Vec<$elem_name> {
-            fn from(sequence_name : $sequence_name) -> Vec<$elem_name> {
-                sequence_name.elements
+        impl$(<$seq_lt>)? From<$sequence_name$(<$seq_lt>)?> for Vec<$elem_name$(<$ele_lt>)?> {
+            fn from(sequence_name: $sequence_name$(<$seq_lt>)?) -> Self {
+                sequence_name.0
             }
         }
     };

--- a/src/types.rs
+++ b/src/types.rs
@@ -833,8 +833,6 @@ impl BERDecodable for GeneralizedTime {
 ///
 /// Octet strings represent contiguous sequences of octets, a.k.a. bytes.
 ///
-/// This type provides the same functionality as [`OctetStringRef`] but owns
-/// the backing data.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct OctetString {
     /// Bitstring represented as a slice of bytes.

--- a/src/types.rs
+++ b/src/types.rs
@@ -894,6 +894,22 @@ impl AsRef<[u8]> for OctetString {
     }
 }
 
+derive_sequence!{
+    /// X.509 `AlgorithmIdentifier` as defined in [RFC 5280 Section 4.1.1.2].
+    ///
+    /// ```text
+    /// AlgorithmIdentifier  ::=  SEQUENCE  {
+    ///      algorithm               OBJECT IDENTIFIER,
+    ///      parameters              ANY DEFINED BY algorithm OPTIONAL  }
+    /// ```
+    ///
+    /// [RFC 5280 Section 4.1.1.2]: https://tools.ietf.org/html/rfc5280#section-4.1.1.2
+    AlgorithmIdentifierOwned {
+        oid: [_] UNTAGGED REQUIRED: ObjectIdentifier,
+        parameters: [_] UNTAGGED OPTIONAL: Option<DerAnyOwned>
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -213,9 +213,9 @@ define_version! {
     ///
     /// [RFC 5280 Section 4.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1
     Version {
-        V1 = 1,
-        V2 = 2,
-        V3 = 3,
+        V1 = 0,
+        V2 = 1,
+        V3 = 2,
     }
 }
 

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -172,9 +172,10 @@ impl<S: BERDecodable + Integer, A: BERDecodable + SignatureAlgorithm, K: BERDeco
 /// ```
 ///
 /// [RFC 5280 § 4.1.2.7]: https://tools.ietf.org/html/rfc5280#section-4.1.2.7
+/// [`AlgorithmIdentifier`]: crate::algorithms::AlgorithmIdentifier
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SubjectPublicKeyInfo<A: SignatureAlgorithm = DerSequence<'static>> {
-    /// X.509 [`AlgorithmIdentifier`] for the public key type
+    /// X.509 [`AlgorithmIdentifier`](crate::algorithms::AlgorithmIdentifier) for the public key type
     pub algorithm: A,
 
     /// Public key data


### PR DESCRIPTION
This PR:

- Enhance macro `derive_sequence` to support optional fields.
- Add a new macro `derive_sequence_of` as a help to define a asn.1 sequence of same type.
- Add a new type  `AlgorithmIdentifierOwned` to represent owned type of X.509 `AlgorithmIdentifier` as defined in [RFC 5280 Section 4.1.1.2](https://tools.ietf.org/html/rfc5280#section-4.1.1.2).
- Refactor implementation of types in https://github.com/fortanix/pkix/pull/21 by using new macros.

- [x] This PR should be merged **after** https://github.com/fortanix/pkix/pull/21