### PR TITLE
Yasna 0.5 and related dependencies upgrades

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,20 @@ repository = "https://github.com/fortanix/pkix"
 exclude = [".gitignore", ".travis.yml", "bors.toml", "CODE_OF_CONDUCT.md"]
 
 [dependencies]
-yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
-num-bigint = { version = "0.2", default-features = false }
+yasna = { version = "0.5", features = ["num-bigint", "bit-vec"] }
+num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 bit-vec = "0.6"
-lazy_static = "1"
-chrono = "0.4.23"
-b64-ct = "0.1.1"
-bitflags = "1.3.2"
+lazy_static = "1.5"
+chrono = "0.4.38"
+b64-ct = "0.1.2"
+bitflags = "2.6"
 
 [dev-dependencies]
 rand = "0.3"
 
 [package.metadata.release]
 tag-prefix = "pkix_"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dont_compile, values("dont_compile"))'] }


### PR DESCRIPTION
For the currently used version of yasna ver0.3, when a specially crafted DER input is provided - it will throw a panic 
due to an integer overflow. The direct impact is that the executing thread aborts.
In order to overcome this vulnerability, it is advised to upgrade to latest yasna ver0.5.2.
This PR upgrades yasna version along with required dependencies.