### PR TITLE
[PLAT-5340] improve: add missing derives to `Ecdsa` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "pkix"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "b64-ct",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkix"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Fortanix Inc."]
 license = "MPL-2.0"
 description = "TLS Certificate encoding and decoding helpers."

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,6 +58,7 @@ impl BERDecodable for RsaPkcs15<Sha256> {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EcdsaX962<H>(pub H);
 
 impl<H> SignatureAlgorithm for EcdsaX962<H> {}


### PR DESCRIPTION
Use the same trait bounds as on the `RsaPkcs15` type